### PR TITLE
Add Block Template Parts and Templates, Add global CSS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,31 @@
 # FSE-theme
 WordPress Full Site Editing theme
+
+## What is included in this Repo: 
+
+- Block Templates.
+- Block Template Parts.
+- Reuse of Block Template Parts.
+- Add Custom Global styles.
+
+## Process:
+
+**Block Template parts** - For eg. Footer, and Header which we can use separately in any block template.
+
+**Steps to create Header Block template Part using Editor.**
+- Go to the editor, click on the template part block, and name it a header. ( Modify Advanced HTML part and add custom CSS class )
+- Hit on the + button and add a group block.
+- Again hit the + button to add a column block. Select any 2-column layout.
+- Add site logo/title/tagline in left column.
+- Add a navigation block in the right column.
+
+**Steps to create Footer Block template Part using Editor.**
+- First 3 steps are common.
+- Add any info inside your footer Block Template Part.
+
+**Steps to create Footer Block template Part for Single Post page**
+- Use header and Footer Template Parts.
+- In between these two Template Parts, Add a 2-column layout to show Post data on the left side and the Sidebar ( Contain search, calender, and gallery ) Template part.
+
+**Note:** All Block Template Parts are `Custom Post Types` and the post_type is `wp_template_part`.
+**Note:** All Block Templates are `Custom Post Types` and the post_type is `wp_temaples` 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # FSE-theme
 WordPress Full Site Editing theme
 
+## FSE Block-Theme setup
+
+- Block-theme must include templates/index.html file. ( Along with index.php & style.css file )
+- Template parts must include inside Parts folder.
+- theme.json file is option but strongly recommended
 ## What is included in this Repo: 
 
 - Block Templates.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ WordPress Full Site Editing theme
 - Block Templates.
 - Block Template Parts.
 - Reuse of Block Template Parts.
-- Add Custom Global styles.
+- Modify Default style using theme.json ( Add custom typography )
 
 ## Process:
 
@@ -31,6 +31,7 @@ WordPress Full Site Editing theme
 **Steps to create Footer Block template Part for Single Post page**
 - Use header and Footer Template Parts.
 - In between these two Template Parts, Add a 2-column layout to show Post data on the left side and the Sidebar ( Contain search, calender, and gallery ) Template part.
+
 
 **Note:** All Block Template Parts are `Custom Post Types` and the post_type is `wp_template_part`.
 **Note:** All Block Templates are `Custom Post Types` and the post_type is `wp_temaples` 

--- a/experimental-theme.json
+++ b/experimental-theme.json
@@ -1,0 +1,5 @@
+{
+    "settings": {
+        "defaults": {}
+    }
+}

--- a/experimental-theme.json
+++ b/experimental-theme.json
@@ -1,5 +1,0 @@
-{
-    "settings": {
-        "defaults": {}
-    }
-}

--- a/functions.php
+++ b/functions.php
@@ -6,12 +6,12 @@
  * @package electra
  */
 
-if ( ! defined( 'ELECTRA_CSS_URI' ) ) {
-    define( 'ELECTRA_CSS_URI', untrailingslashit( get_template_directory_uri() ) . '/assets/css' );
+if ( ! defined( 'FSE_BLOCK_THEME_CSS_URI' ) ) {
+    define( 'FSE_BLOCK_THEME_CSS_URI', untrailingslashit( get_template_directory_uri() ) . '/assets/css' );
 }
 
-if ( ! defined( 'ELECTRA_CSS_DIR_PATH' ) ) {
-    define( 'ELECTRA_CSS_DIR_PATH', untrailingslashit( get_template_directory() ) . '/assets/css' );
+if ( ! defined( 'FSE_BLOCK_THEME_CSS_DIR_PATH' ) ) {
+    define( 'FSE_BLOCK_THEME_CSS_DIR_PATH', untrailingslashit( get_template_directory() ) . '/assets/css' );
 }
 
 /**
@@ -19,7 +19,7 @@ if ( ! defined( 'ELECTRA_CSS_DIR_PATH' ) ) {
  *
  * @return void
  */
-function electra_setup_theme() {
+function fse_block_theme_setup_theme() {
 
     /**
      * Enable support for Post Thumbnails on posts and pages.
@@ -81,14 +81,20 @@ function electra_setup_theme() {
     ] );
 }
 
-add_action( 'after_setup_theme', 'electra_setup_theme' );
+add_action( 'after_setup_theme', 'fse-block-theme' );
 
 /**
  * Register Styles.
  */
-function electra_register_styles() {
-    wp_register_style( 'main-css', ELECTRA_CSS_URI . '/main.css', [], filemtime( ELECTRA_CSS_DIR_PATH . '/main.css' ), 'all' );
+function fse_block_theme_register_styles() {
+    wp_register_style(
+        'main-css',
+        FSE_BLOCK_THEME_CSS_URI . '/main.css',
+        array(),
+        filemtime( FSE_BLOCK_THEME_CSS_DIR_PATH . '/main.css' ),
+        'all',
+    );
     wp_enqueue_style( 'main-css' );
 }
 
-add_action( 'wp_enqueue_scripts', 'electra_register_styles' );
+add_action( 'wp_enqueue_scripts', 'fse_block_theme_register_styles' );

--- a/parts/footer.html
+++ b/parts/footer.html
@@ -1,0 +1,25 @@
+<!-- wp:group -->
+<div class="wp-block-group"><!-- wp:columns -->
+<div class="wp-block-columns"><!-- wp:column -->
+<div class="wp-block-column"><!-- wp:site-title /-->
+
+<!-- wp:paragraph -->
+<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum</p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:column -->
+
+<!-- wp:column -->
+<div class="wp-block-column"><!-- wp:categories /--></div>
+<!-- /wp:column -->
+
+<!-- wp:column -->
+<div class="wp-block-column"><!-- wp:latest-comments /--></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns -->
+
+<!-- wp:group {"backgroundColor":"black","textColor":"white"} -->
+<div class="wp-block-group has-white-color has-black-background-color has-text-color has-background"><!-- wp:paragraph {"align":"center"} -->
+<p class="has-text-align-center">Devanshi Joshi @ 2022</p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:group --></div>
+<!-- /wp:group -->

--- a/parts/header.html
+++ b/parts/header.html
@@ -1,0 +1,13 @@
+<!-- wp:group -->
+<div class="wp-block-group"><!-- wp:columns -->
+<div class="wp-block-columns"><!-- wp:column {"width":"33.33%"} -->
+<div class="wp-block-column" style="flex-basis:33.33%"><!-- wp:site-title /-->
+
+<!-- wp:site-tagline /--></div>
+<!-- /wp:column -->
+
+<!-- wp:column {"width":"66.66%"} -->
+<div class="wp-block-column" style="flex-basis:66.66%"><!-- wp:navigation {"ref":12} /--></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns --></div>
+<!-- /wp:group -->

--- a/parts/sidebar.html
+++ b/parts/sidebar.html
@@ -1,0 +1,11 @@
+<!-- wp:group -->
+<div class="wp-block-group"><!-- wp:search {"label":"Search","buttonText":"Search"} /-->
+
+<!-- wp:calendar /-->
+
+<!-- wp:gallery {"linkTo":"none"} -->
+<figure class="wp-block-gallery has-nested-images columns-default is-cropped"><!-- wp:image {"id":38,"sizeSlug":"large","linkDestination":"none"} -->
+<figure class="wp-block-image size-large"><img src="http://fse.local/wp-content/uploads/2022/06/img1.jpg" alt="" class="wp-image-38"/></figure>
+<!-- /wp:image --></figure>
+<!-- /wp:gallery --></div>
+<!-- /wp:group -->

--- a/style.css
+++ b/style.css
@@ -1,10 +1,10 @@
 /*
-Theme Name: Electra
+Theme Name: FSC Block Theme
 Theme URI: https://github.com/devanshijoshi9/fsc-theme
 Author: Devanshi Joshi
 Description: Full Site Editing WordPress Theme 
 Requires at least: 5.3
 Version: 0.1
-Text Domain: electra
+Text Domain: fsc-block-theme
 Tags: block-based-theme, full-site-editing
  */

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,29 @@
+<!-- wp:template-part {"slug":"header"} /-->
+
+<!-- wp:group {"tagName":"main"} -->
+<main id="site-content" class="wp-block-group"><!-- wp:query {"queryId":45,"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false}} -->
+<div class="wp-block-query"><!-- wp:post-template -->
+<!-- wp:post-featured-image /-->
+
+<!-- wp:post-date /-->
+
+<!-- wp:post-title {"isLink":true,"linkTarget":"_blank"} /-->
+<!-- /wp:post-template -->
+
+<!-- wp:query-pagination -->
+<!-- wp:query-pagination-previous /-->
+
+<!-- wp:query-pagination-numbers /-->
+
+<!-- wp:query-pagination-next /-->
+<!-- /wp:query-pagination -->
+
+<!-- wp:query-no-results -->
+<!-- wp:paragraph {"placeholder":"Add text or blocks that will display when the query returns no results."} -->
+<p>No Post found</p>
+<!-- /wp:paragraph -->
+<!-- /wp:query-no-results --></div>
+<!-- /wp:query --></main>
+<!-- /wp:group -->
+
+<!-- wp:template-part {"slug":"footer"} /-->

--- a/templates/single.html
+++ b/templates/single.html
@@ -1,0 +1,25 @@
+<!-- wp:template-part {"slug":"header"} /-->
+
+<!-- wp:group {"tagName":"main","className":"site-content"} -->
+<main class="wp-block-group site-content"><!-- wp:columns -->
+<div class="wp-block-columns"><!-- wp:column {"width":"66.66%"} -->
+<div class="wp-block-column" style="flex-basis:66.66%"><!-- wp:group -->
+<div class="wp-block-group"><!-- wp:post-title /-->
+
+<!-- wp:post-date /-->
+
+<!-- wp:post-author /-->
+
+<!-- wp:post-featured-image /-->
+
+<!-- wp:post-content /--></div>
+<!-- /wp:group --></div>
+<!-- /wp:column -->
+
+<!-- wp:column {"width":"33.33%"} -->
+<div class="wp-block-column" style="flex-basis:33.33%"><!-- wp:template-part {"slug":"sidebar"} /--></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns --></main>
+<!-- /wp:group -->
+
+<!-- wp:template-part {"slug":"footer"} /-->

--- a/theme.json
+++ b/theme.json
@@ -21,7 +21,18 @@
             "palette": [],
             "text": true
         },
-        "custom": {},
+        "custom": {
+			"typography": {
+                "scale": 1.250,
+				"normal": "1rem",
+                "tiny":   "calc(var(--wp--custom--typography--small) / var(--wp--custom--typography--scale))",
+                "small":   "calc(var(--wp--custom--typography--normal) / var(--wp--custom--typography--scale))",
+                "large":   "calc(var(--wp--custom--typography--normal) * var(--wp--custom--typography--scale))",
+                "extra-large":   "calc(var(--wp--custom--typography--large) * var(--wp--custom--typography--scale))",
+                "huge":  "calc(var(--wp--custom--typography--extra-large) * var(--wp--custom--typography--scale))",
+                "gigantic": "calc(var(--wp--custom--typography--huge) * var(--wp--custom--typography--scale))"
+            }
+		},
         "layout": {
             "contentSize": "800px",
             "wideSize": "1000px"
@@ -36,7 +47,18 @@
             "customFontSize": true,
             "dropCap": true,
             "fontFamilies": [],
-            "fontSizes": [],
+            "fontSizes": [
+				{
+					"name": "Large",
+					"size": "clamp(var(--wp--custom--typography--normal), calc(1rem + var(--wp--custom--typography--large--preferred, 3vw)), var(--wp--custom--typography--large))",
+					"slug": "large"
+				},
+				{
+					"name": "Extra Large",
+					"size": "clamp(var(--wp--custom--typography--large), calc(1rem + var(--wp--custom--typography--extra-large--preferred, 4vw)), var(--wp--custom--typography--extra-large))",
+					"slug": "extra-large"
+				}
+			],
             "fontStyle": true,
             "fontWeight": true,
             "letterSpacing": true,

--- a/theme.json
+++ b/theme.json
@@ -1,0 +1,60 @@
+{
+    "version": 2,
+    "settings": {
+        "appearanceTools": false,
+        "border": {
+            "color": false,
+            "radius": false,
+            "style": false,
+            "width": false
+        },
+        "color": {
+            "background": true,
+            "custom": true,
+            "customDuotone": true,
+            "customGradient": true,
+            "defaultGradients": true,
+            "defaultPalette": true,
+            "duotone": [],
+            "gradients": [],
+            "link": true,
+            "palette": [],
+            "text": true
+        },
+        "custom": {},
+        "layout": {
+            "contentSize": "800px",
+            "wideSize": "1000px"
+        },
+        "spacing": {
+            "blockGap": null,
+            "margin": false,
+            "padding": false,
+            "units": [ "px", "em", "rem", "vh", "vw" ]
+        },
+        "typography": {
+            "customFontSize": true,
+            "dropCap": true,
+            "fontFamilies": [],
+            "fontSizes": [],
+            "fontStyle": true,
+            "fontWeight": true,
+            "letterSpacing": true,
+            "lineHeight": false,
+            "textDecoration": true,
+            "textTransform": true
+        },
+        "blocks": {
+            "core/paragraph": {
+                "border": {},
+                "color": {},
+                "custom": {},
+                "layout": {},
+                "spacing": {},
+                "typography": {}
+            },
+            "core/heading": {},
+            "etc": {}
+        }
+    }
+}


### PR DESCRIPTION
**Block Template parts** - For eg. Footer, and Header which we can use separately in any block template.

**Steps to create Header Block template Part using Editor.**
- Go to the editor, click on the template part block, and name it a header. ( Modify Advanced HTML part and add custom CSS class )
- Hit on the + button and add a group block.
- Again hit the + button to add a column block. Select any 2-column layout.
- Add site logo/title/tagline in left column.
- Add a navigation block in the right column.

**Steps to create Footer Block template Part using Editor.**
- First 3 steps are common.
- Add any info inside your footer Block Template Part.

**Steps to create Footer Block template Part for Single Post page**
- Use header and Footer Template Parts.
- In between these two Template Parts, Add a 2-column layout to show Post data on the left side and the Sidebar ( Contain search, calender, and gallery ) Template part.

**Note:** All Block Template Parts are `Custom Post Types` and the post_type is `wp_template_part`.
**Note:** All Block Templates are `Custom Post Types` and the post_type is `wp_temaples` 